### PR TITLE
Update Airbrake Heroku addon name

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,6 +8,6 @@
   },
   "addons": [
     "logentries:le_tryit",
-    "airbrake:free_heroku"
+    "airbrake:free-hrku"
   ]
 }


### PR DESCRIPTION
Airbrake has changed the name of their free plan on Heroku.
